### PR TITLE
Add alternative solution P1221

### DIFF
--- a/P1221.apln
+++ b/P1221.apln
@@ -4,5 +4,8 @@
     (⎕IO ⎕ML) ← 0 1       
     
     ⍝ Inspired by Iverson's APL code to check if a string has balanced parens.
-    Sol ← {+⌿0=+⍀-⌿'RL'∘.=⍵}
+    Sol1 ← {+⌿0=+⍀-⌿'RL'∘.=⍵}
+    
+    ⍝ Same method, different way
+    Sol2 ← {+/0=+\(~-⊢)'R'=⍵}
 :EndNamespace


### PR DESCRIPTION
 - [x] I tested my solutions with the respective test cases from the LeetCode.com website;
 - [x] I added a couple of comments with an overview of how my solutions work;
   - [ ] I included my GitHub nickname (optional);
 - [x] My solutions were added at the _bottom_ of the solutions that already existed;
 - [x] I added my solutions to the runtime comparison tradfns, when such tradfns were present.

This solution is not that different from the one already there, but I think it is quite more "beautiful". However, it is a bit less efficient:
```apl
s ← 'RLRRLLRLRL' 'RLLLLRRRLR'
Sol1 ← {+⌿0=+⍀-⌿'RL'∘.=⍵}
Sol2 ← {+/0=+\(~-⊢)'R'=⍵}
cmpx 'Sol1¨s' 'Sol2¨s'

Sol1¨s → 3.4E¯6 |  0% ⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕
Sol2¨s → 3.8E¯6 | +9% ⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕
```
I hope someone can explain to me why the first solution is better than the second one since I thought it would be the opposite.